### PR TITLE
Removed "http" from "import url".

### DIFF
--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700,300);
+@import url(//fonts.googleapis.com/css?family=Roboto:400,700,300);
 .clearfix {
   *zoom: 1;
 }


### PR DESCRIPTION
Using a protocol free url avoids "blocked mixed content" errors when website uses https.
